### PR TITLE
Readme badges linking to relevant GCS buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-[![CircleCI](https://circleci.com/gh/stackrox/kernel-packer.svg?&style=shield&circle-token=f65a92f3c16297b0433428aa9284803d1b649e72)](https://circleci.com/gh/stackrox/kernel-packer/tree/master)
+[![CircleCI][circleci-badge]][circleci-link]
+[![GCS Packages][gcs-packages-badge]][gcs-packages-link]
+[![GCS Bundles][gcs-bundles-badge]][gcs-bundles-link]
 
 # Kernel Packer
 
 📦 Crawl and repackage kernel headers for collector
+
+[circleci-badge]:      https://circleci.com/gh/stackrox/kernel-packer.svg?&style=shield&circle-token=f65a92f3c16297b0433428aa9284803d1b649e72
+[circleci-link]:       https://circleci.com/gh/stackrox/kernel-packer/tree/master
+[gcs-bundles-badge]:   https://img.shields.io/badge/gcs-kernel%20bundles-blue.svg?style=flat&logo=google
+[gcs-bundles-link]:    https://console.cloud.google.com/storage/browser/stackrox-kernel-bundles?project=stackrox-collector
+[gcs-packages-badge]:  https://img.shields.io/badge/gcs-kernel%20packages-blue.svg?style=flat&logo=google
+[gcs-packages-link]:   https://console.cloud.google.com/storage/browser/stackrox-kernel-packages?project=stackrox-collector


### PR DESCRIPTION
So folks don't have to go digging through the code/GCS console to find the right buckets 🙂 