### PR TITLE
Workaround patch for COS kernels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
     - gcloud-init
     - checkout
     - restore_cache:
-        key: stackrox-kernel-packer-cache-v9
+        key: stackrox-kernel-packer-cache-v10
     - run:
         name: Sanity check cache
         command: |
@@ -98,7 +98,7 @@ jobs:
         name: Sanity check cache
         command: cat .build-data/cache/cache.yml
     - save_cache:
-        key: stackrox-kernel-packer-cache-v9-{{ epoch }}
+        key: stackrox-kernel-packer-cache-v10-{{ epoch }}
         paths:
         - .build-data/cache/cache.yml
 

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -221,6 +221,11 @@ repackage_cos() {
         # Copy fixed kernel config 
         cp /etc/includes/cos/.config .
 
+        # COS 4.14 kernels contain a backport that included anonymous structs 
+        # for clang which breaks access to task_struct.
+        sed -i '/^#define randomized_struct_fields_start	struct {$/d' include/linux/compiler-clang.h
+        sed -i '/^#define randomized_struct_fields_end	};$/d' include/linux/compiler-clang.h
+
         # Prepare kernel sources for module compilation
         make olddefconfig > /dev/null
         make modules_prepare > /dev/null


### PR DESCRIPTION
COS 4.14 kernels contain a backport that included anonymous structs for clang which breaks access to task_struct in the bpf probe