### PR TITLE
Update and enable debian crawler

### DIFF
--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -38,3 +38,4 @@ crawl: build-crawl-container crawl-kops crawl-amazon
 	docker run --rm -i kernel-crawler crawl Ubuntu-Azure > $(CRAWLED_PACKAGE_DIR)/ubuntu-azure.txt
 	docker run --rm -i kernel-crawler crawl Ubuntu-GKE > $(CRAWLED_PACKAGE_DIR)/ubuntu-gke.txt
 	docker run --rm -i kernel-crawler crawl Ubuntu-GCP > $(CRAWLED_PACKAGE_DIR)/ubuntu-gcp.txt
+	docker run --rm -i kernel-crawler crawl Debian > $(CRAWLED_PACKAGE_DIR)/debian.txt

--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -138,7 +138,7 @@ repos = {
     ],
     "Debian": [
         {
-            "root": "http://ftp.us.debian.org/debian/pool/main/l/",
+            "root": "http://security.debian.org/pool/updates/main/l/",
             "discovery_pattern": "/html/body//a[regex:test(@href, '^linux/')]/@href",
             "subdirs": [""],
             "page_pattern": "/html/body//a[regex:test(@href, '^linux-(?:headers-[0-9.]+-[^-]+-(?:amd64|common_)|kbuild-.*_4.9.130).*(?:amd64|all).deb$')]/@href",

--- a/kernel-package-lists/debian.txt
+++ b/kernel-package-lists/debian.txt
@@ -1,5 +1,12 @@
-http://ftp.us.debian.org/debian/pool/main/l/linux/linux-kbuild-4.9_4.9.130-2_amd64.deb
-http://ftp.us.debian.org/debian/pool/main/l/linux/linux-headers-4.9.0-8-common_4.9.130-2_all.deb
-http://ftp.us.debian.org/debian/pool/main/l/linux/linux-headers-4.9.0-8-amd64_4.9.130-2_amd64.deb
-http://ftp.us.debian.org/debian/pool/main/l/linux/linux-headers-4.9.0-0.bpo.6-common_4.9.88-1+deb9u1~bpo8+1_all.deb
-http://ftp.us.debian.org/debian/pool/main/l/linux/linux-headers-4.9.0-0.bpo.6-amd64_4.9.88-1+deb9u1~bpo8+1_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-6-amd64_4.9.88-1+deb9u1_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-4-amd64_4.9.65-3+deb9u1_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-7-amd64_4.9.110-3+deb9u2_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-5-amd64_4.9.65-3+deb9u2_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-3-amd64_4.9.30-2+deb9u5_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-8-amd64_4.9.110-3+deb9u6_amd64.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-6-common_4.9.88-1+deb9u1_all.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-4-common_4.9.65-3+deb9u1_all.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-7-common_4.9.110-3+deb9u2_all.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-5-common_4.9.65-3+deb9u2_all.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-3-common_4.9.30-2+deb9u5_all.deb
+http://security.debian.org/pool/updates/main/l/linux/linux-headers-4.9.0-8-common_4.9.110-3+deb9u6_all.deb


### PR DESCRIPTION
This probably doesn't work out of the box, not sure what else needs to happen to make sure these kernels are included (and we probably still need the kbuild package).