### PR TITLE
Add 4.19.76-12371.89.0-cos

### DIFF
--- a/kernel-package-lists/cos.txt
+++ b/kernel-package-lists/cos.txt
@@ -209,3 +209,4 @@ https://storage.googleapis.com/cos-tools/11021.99.0/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/10323.99.0/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/11316.99.0/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/10895.299.0/kernel-src.tar.gz
+https://storage.googleapis.com/cos-tools/12371.89.0/kernel-src.tar.gz

--- a/kernel-package-lists/manifest.yml
+++ b/kernel-package-lists/manifest.yml
@@ -2252,6 +2252,10 @@
   type: redhat
   packages:
   - https---cdn.redhat.com-content-dist-rhel-server-6-6Server-x86_64-os-Packages-k-kernel-devel-2.6.32-642.el6.x86_64.rpm
+321b857a14b2b83ccb03b0e165e1e433b399b5c926b49bab0909d9ed04d20431:
+  type: cos
+  packages:
+  - https---storage.googleapis.com-cos-tools-12371.89.0-kernel-src.tar.gz
 329e02b0606c984e62b1470fa89869bf5d9a1d5eaf6aaf6d1e04954453a636d5:
   type: ubuntu
   packages:


### PR DESCRIPTION
Manually add COS stable (https://cloud.google.com/container-optimized-os/docs/release-notes#cos-stable-77-12371-89-0) as temporary fix for COS scraping