### PR TITLE
Scrape ubuntu gke 5.0 kernels

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -373,6 +373,16 @@ repos = {
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-[4-9].*-gke.*_amd64.deb$')]/@href",
             "exclude_patterns": ubuntu_excludes
         },
+
+        # linux-gke-5.0 AMD64 headers, distributed from main
+        {
+            "root" : "http://security.ubuntu.com/ubuntu/pool/universe/l/",
+            "discovery_pattern" : "/html/body//a[@href = 'linux-gke-5.0/']/@href",
+            "subdirs" : [""],
+            "page_pattern" : "/html/body//a[regex:test(@href, '^linux-gke-5.0-headers-[4-9].*_amd64.deb$')]/@href",
+            "exclude_patterns": ubuntu_excludes
+        },
+
     ],
     "Oracle-UEK5": [
     	{


### PR DESCRIPTION
Add a new path under `http://security.ubuntu.com/ubuntu/pool/universe/l/` so that we can pick up `5.0-gke` kernels.