### PR TITLE
Remove ubuntu exclusions

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -255,12 +255,12 @@ repos = {
             "exclude_patterns": ubuntu_excludes + ubuntu_backport_excludes
         },
 
+        # Special case for Ubuntu Azure kernel 4.18, that only exists as a backport.
         # linux-azure 4.18 backports AMD64 headers, distributed from main
         {
             "root" : "http://security.ubuntu.com/ubuntu/pool/main/l/",
             "discovery_pattern" : "/html/body//a[@href = 'linux-azure/']/@href",
             "subdirs" : [""],
-            #linux-headers-4.18.0-1020-azure_4.18.0-1020.20~18.04.1_amd64.deb
             "page_pattern" : "/html/body//a[regex:test(@href, '^linux-headers-4\.18[-.0-9]+azure_4\.18[-.0-9]+~.*amd64.deb$')]/@href",
             "exclude_patterns": ubuntu_excludes
         },


### PR DESCRIPTION
- Remove exclusions for ubuntu 4.18/4.19 kernels that are out of date, collector supports these kernels.
- Make a special case for ubuntu backports for azure kernel version 4.18. This looks to be the only special case needed (5.0 and 4.19 kernels are captured outside of backports)