### PR TITLE
Temporarily silence errors crawling errors and keep going

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include Makefile-constants.mk
 # Crawl kernel package repositories and record discovered packages.
 .PHONY: crawl
 crawl:
-	make -C kernel-crawler crawl
+	-make --keep-going -C kernel-crawler crawl
 
 .PHONY: manifest
 manifest: package-inventory


### PR DESCRIPTION
Until the RedHat update service errors are resolved, silence the error and continue to crawl other distributions.