### PR TITLE
Revert "temporarily silence errors crawling errors and keep going (#94)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include Makefile-constants.mk
 # Crawl kernel package repositories and record discovered packages.
 .PHONY: crawl
 crawl:
-	-make --keep-going -C kernel-crawler crawl
+	make -C kernel-crawler crawl
 
 .PHONY: manifest
 manifest: package-inventory


### PR DESCRIPTION
This reverts commit 6e82da3ea587bd599ccd37bec38c60512949e9cd.
RHEL crawling is now working properly.