### PR TITLE
add flatcar beta one-off for 5.4.62-flatcar

### DIFF
--- a/kernel-package-lists/flatcar-beta.txt
+++ b/kernel-package-lists/flatcar-beta.txt
@@ -1,1 +1,2 @@
 https://beta.release.flatcar-linux.net/amd64-usr/2513.2.0/flatcar_developer_container.bin.bz2
+https://beta.release.flatcar-linux.net/amd64-usr/2605.3.0/flatcar_developer_container.bin.bz2


### PR DESCRIPTION
Flatcar beta previously added as a one-off https://github.com/stackrox/kernel-packer/pull/91/