### PR TITLE
Fix gcloud installation failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,10 +165,6 @@ jobs:
     - gcloud-init
     - checkout
     - run:
-        name: Generate manifest
-        command: |
-            circleci step halt
-    - run:
         name: Crawl package repositories
         command: make crawl
     - run:


### PR DESCRIPTION
The latest pip (version 21) removed support for python 2. https://pip.pypa.io/en/stable/news/#id1 This change pins the pip upgrade to version 20.x until we upgrade to python 3.