### PR TITLE
Add Garden Linux kernel 5.4.0-6

### DIFF
--- a/kernel-package-lists/gardenlinux-uncrawled.txt
+++ b/kernel-package-lists/gardenlinux-uncrawled.txt
@@ -1,3 +1,6 @@
 http://18.185.215.86/packages/linux-headers-5.4.0-5-common_5.4.68-1_all.deb
 http://18.185.215.86/packages/linux-headers-5.4.0-5-cloud-amd64_5.4.68-1_amd64.deb
 http://18.185.215.86/packages/linux-kbuild-5.4_5.4.68-1_amd64.deb
+http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-amd64_5.4.93-1_amd64.deb
+http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-cloud-amd64_5.4.93-1_amd64.deb
+http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-kbuild-5.4_5.4.93-1_amd64.deb


### PR DESCRIPTION
Manually add garden linux kernel headers for [5.4.0-6-cloud-amd64](https://srox.slack.com/archives/CGZGUML6Q/p1620422905000500).  Garden Linux crawling is broken at the moment because they are now using their own kernel builds (the 5.4 family is beyond LTS support in Debian).


Reverse engineered packages from this commit: https://github.com/gardenlinux/gardenlinux/commit/254f287aa20721ee550bcb8e032258e08c68030c#diff-4aa029e4340e17785cff736c702abe13cecf3f20769a923e3b3c3bd3481acb54