### PR TITLE
ROX-7108 Fix manifest generation for latest uncrawled garden linux kernel headers

### DIFF
--- a/tools/generate-manifest/reformatters/reformatters.go
+++ b/tools/generate-manifest/reformatters/reformatters.go
@@ -81,12 +81,12 @@ func reformatOneToPairs(packages []string) ([][]string, error) {
 }
 
 var (
-	debianKBuildVersionRegex = regexp.MustCompile(`^linux-kbuild-(\d+(?:\.\d+)*)_([^_]+)(?:_.*)?\.deb$`)
-	debianHeaderVersionRegex = regexp.MustCompile(`^linux-headers-(\d+(?:\.\d+)*-\d+)-[^_]+_([^_]+)(?:_.*)?\.deb$`)
-	gardenHeaderVersionRegex = regexp.MustCompile(`^linux-headers(?:-cloud)?-amd64_([^_]+)(?:_.*)?\.deb$`)
+	debianKBuildVersionRegex      = regexp.MustCompile(`^linux-kbuild-(\d+(?:\.\d+)*)_([^_]+)(?:_.*)?\.deb$`)
+	debianHeaderVersionRegex      = regexp.MustCompile(`^linux-headers-(\d+(?:\.\d+)*-\d+)-[^_]+_([^_]+)(?:_.*)?\.deb$`)
+	gardenHeaderVersionRegex      = regexp.MustCompile(`^linux-headers(?:-cloud)?-amd64_([^_]+)(?:_.*)?\.deb$`)
 	debianCommonPackageIndicators = regexp.MustCompile("common|linux-headers-amd64_")
-	versionSepRegex          = regexp.MustCompile(`[-.]`)
-	debianSecurityURL        = "security.debian.org"
+	versionSepRegex               = regexp.MustCompile(`[-.]`)
+	debianSecurityURL             = "security.debian.org"
 )
 
 type packageInfo struct {

--- a/tools/generate-manifest/reformatters/reformatters_test.go
+++ b/tools/generate-manifest/reformatters/reformatters_test.go
@@ -1,0 +1,55 @@
+package reformatters
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGardenLinuxUncrawled(t *testing.T) {
+	tests := []struct {
+		name string
+		input []string
+		expected [][]string
+	}{
+		{
+			name: "working",
+			input: []string{
+				"http://18.185.215.86/packages/linux-headers-5.4.0-5-common_5.4.68-1_all.deb",
+				"http://18.185.215.86/packages/linux-headers-5.4.0-5-cloud-amd64_5.4.68-1_amd64.deb",
+				"http://18.185.215.86/packages/linux-kbuild-5.4_5.4.68-1_amd64.deb",
+			},
+			expected: [][]string{{
+				"http://18.185.215.86/packages/linux-headers-5.4.0-5-common_5.4.68-1_all.deb",
+				"http://18.185.215.86/packages/linux-headers-5.4.0-5-cloud-amd64_5.4.68-1_amd64.deb",
+				"http://18.185.215.86/packages/linux-kbuild-5.4_5.4.68-1_amd64.deb",
+			}},
+		},
+		{
+			name: "irregular package name",
+			input: []string{
+				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-amd64_5.4.93-1_amd64.deb",
+				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-cloud-amd64_5.4.93-1_amd64.deb",
+				"http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-kbuild-5.4_5.4.93-1_amd64.deb",
+			},
+			expected: [][]string{{
+				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-amd64_5.4.93-1_amd64.deb",
+				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-cloud-amd64_5.4.93-1_amd64.deb",
+				"http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-kbuild-5.4_5.4.93-1_amd64.deb",
+			}},
+		},
+	}
+
+	for index, test := range tests {
+		name := fmt.Sprintf("%d %s", index+1, test.name)
+		t.Run(name, func(t *testing.T) {
+			actual,err := reformatDebian(test.input)
+			assert.Nil(t, err)
+			assert.Equal(t, len(test.expected), len(actual))
+			for i := range actual {
+				assert.ElementsMatch(t, test.expected[i], actual[i])
+			}
+		})
+	}
+}

--- a/tools/generate-manifest/reformatters/reformatters_test.go
+++ b/tools/generate-manifest/reformatters/reformatters_test.go
@@ -11,7 +11,6 @@ func TestGardenLinuxUncrawled(t *testing.T) {
 	tests := []struct {
 		name string
 		input []string
-		expected [][]string
 	}{
 		{
 			name: "working",
@@ -20,11 +19,6 @@ func TestGardenLinuxUncrawled(t *testing.T) {
 				"http://18.185.215.86/packages/linux-headers-5.4.0-5-cloud-amd64_5.4.68-1_amd64.deb",
 				"http://18.185.215.86/packages/linux-kbuild-5.4_5.4.68-1_amd64.deb",
 			},
-			expected: [][]string{{
-				"http://18.185.215.86/packages/linux-headers-5.4.0-5-common_5.4.68-1_all.deb",
-				"http://18.185.215.86/packages/linux-headers-5.4.0-5-cloud-amd64_5.4.68-1_amd64.deb",
-				"http://18.185.215.86/packages/linux-kbuild-5.4_5.4.68-1_amd64.deb",
-			}},
 		},
 		{
 			name: "irregular package name",
@@ -33,11 +27,6 @@ func TestGardenLinuxUncrawled(t *testing.T) {
 				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-cloud-amd64_5.4.93-1_amd64.deb",
 				"http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-kbuild-5.4_5.4.93-1_amd64.deb",
 			},
-			expected: [][]string{{
-				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-amd64_5.4.93-1_amd64.deb",
-				"http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/linux-headers-cloud-amd64_5.4.93-1_amd64.deb",
-				"http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-kbuild-5.4_5.4.93-1_amd64.deb",
-			}},
 		},
 	}
 
@@ -46,10 +35,8 @@ func TestGardenLinuxUncrawled(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual,err := reformatDebian(test.input)
 			assert.Nil(t, err)
-			assert.Equal(t, len(test.expected), len(actual))
-			for i := range actual {
-				assert.ElementsMatch(t, test.expected[i], actual[i])
-			}
+			assert.Equal(t, 1, len(actual))
+			assert.ElementsMatch(t, test.input, actual[0])
 		})
 	}
 }

--- a/tools/generate-manifest/reformatters/reformatters_test.go
+++ b/tools/generate-manifest/reformatters/reformatters_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGardenLinuxUncrawled(t *testing.T) {
 	tests := []struct {
-		name string
+		name  string
 		input []string
 	}{
 		{
@@ -33,7 +33,7 @@ func TestGardenLinuxUncrawled(t *testing.T) {
 	for index, test := range tests {
 		name := fmt.Sprintf("%d %s", index+1, test.name)
 		t.Run(name, func(t *testing.T) {
-			actual,err := reformatDebian(test.input)
+			actual, err := reformatDebian(test.input)
 			assert.Nil(t, err)
 			assert.Equal(t, 1, len(actual))
 			assert.ElementsMatch(t, test.input, actual[0])


### PR DESCRIPTION
Handle non-standard garden linux package name format.

A previous commit added the uncrawled garden linux headers but they were silently ignored by manifest generation.
