### PR TITLE
ROX-7117 openshift 3.11 hotfix kernel 3.10.0-1062.13.1.el7.x86_64

### DIFF
--- a/kernel-package-lists/reformat.yml
+++ b/kernel-package-lists/reformat.yml
@@ -196,6 +196,12 @@
   file: rhel8-rhocp4.5.txt
   reformat: single
 
+- name: rhel-uncrawled
+  description: RHEL uncrawled kernels
+  type: redhat
+  file: rhel-uncrawled.txt
+  reformat: single
+
 - name: suse
   description: SUSE
   type: suse

--- a/kernel-package-lists/rhel-uncrawled.txt
+++ b/kernel-package-lists/rhel-uncrawled.txt
@@ -1,0 +1,2 @@
+# The below package is a hotfix kernel, availible from internal server
+http://download.eng.bos.redhat.com/brewroot/vol/kernelarchive/packages/kernel/3.10.0/1062.13.1.el7/x86_64/kernel-devel-3.10.0-1062.13.1.el7.x86_64.rpm


### PR DESCRIPTION
Manually downloaded, on RH VPN, the kernel header package for a hotfix kernel version that was delivered to a customer by RH, and later encountered in an ACS POC.

https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1048327

Verified package was built with correct version.

From the `combine` job:

```
3.10.0-1062.13.1.el7.x86_64
```