### PR TITLE
ROX-7108 Use different packages for uncrawled Garden Linux

### DIFF
--- a/kernel-package-lists/gardenlinux-uncrawled.txt
+++ b/kernel-package-lists/gardenlinux-uncrawled.txt
@@ -1,6 +1,6 @@
 http://18.185.215.86/packages/linux-headers-5.4.0-5-common_5.4.68-1_all.deb
 http://18.185.215.86/packages/linux-headers-5.4.0-5-cloud-amd64_5.4.68-1_amd64.deb
 http://18.185.215.86/packages/linux-kbuild-5.4_5.4.68-1_amd64.deb
-http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-headers-5.4.0-6-amd64_5.4.93-1_amd64.deb
 http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-headers-5.4.0-6-common_5.4.93-1_all.deb
+http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-headers-5.4.0-6-cloud-amd64_5.4.93-1_amd64.deb
 http://45.86.152.1/gardenlinux/pool/main/l/linux/linux-kbuild-5.4_5.4.93-1_amd64.deb


### PR DESCRIPTION
Added correct header paths for kernel package for Garden Linux version 5.4.0-6-cloud-amd64.

Verified that the correct kernel version was built and bundle was created.
