### PR TITLE
ROX-7516 - missing kernel probe for 5.3.18-59.10-default

### DIFF
--- a/kernel-crawler/suse/repo-names.txt
+++ b/kernel-crawler/suse/repo-names.txt
@@ -5,3 +5,4 @@ SLE-Product-SLES15-LTSS-Updates
 SLE-Module-Basesystem15-Updates
 SLE-Module-Basesystem15-SP1-Updates
 SLE-Module-Basesystem15-SP2-Updates
+SLE-Module-Basesystem15-SP3-Updates


### PR DESCRIPTION
Added Suse 15 - SP3 in the list of suse repository names.

https://www.suse.com/support/update/announcement/2021/suse-su-20212184-1/