### PR TITLE
Add 4.18.0-240.23.2.el8_3.x86_64 for latest OpenShift 4.7 installs

### DIFF
--- a/kernel-package-lists/rhel-uncrawled.txt
+++ b/kernel-package-lists/rhel-uncrawled.txt
@@ -1,3 +1,4 @@
 # The below packages are a hotfix or beta kernels, available from internal Red Hat server.
 http://download.eng.bos.redhat.com/brewroot/vol/kernelarchive/packages/kernel/3.10.0/1062.13.1.el7/x86_64/kernel-devel-3.10.0-1062.13.1.el7.x86_64.rpm
 http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/kernel/4.18.0/293.el8/x86_64/kernel-devel-4.18.0-293.el8.x86_64.rpm
+http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/kernel/4.18.0/240.23.2.el8_3/x86_64/kernel-devel-4.18.0-240.23.2.el8_3.x86_64.rpm


### PR DESCRIPTION
Similar to #146 https://docs.engineering.redhat.com/display/RHELPLAN/RHEL+Kernel+Version+Table+RHEL+8.3.z+Stream