### PR TITLE
Manually add RHEL "hotfix" kernel for Openshift 4.7.21

### DIFF
--- a/kernel-package-lists/rhel-uncrawled.txt
+++ b/kernel-package-lists/rhel-uncrawled.txt
@@ -1,3 +1,4 @@
 # The below packages are a hotfix or beta kernels, available from internal Red Hat server.
 http://download.eng.bos.redhat.com/brewroot/vol/kernelarchive/packages/kernel/3.10.0/1062.13.1.el7/x86_64/kernel-devel-3.10.0-1062.13.1.el7.x86_64.rpm
 http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/kernel/4.18.0/293.el8/x86_64/kernel-devel-4.18.0-293.el8.x86_64.rpm
+http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/kernel/4.18.0/240.23.2.el8_3/x86_64/kernel-devel-4.18.0-240.23.2.el8_3.x86_64.rpm


### PR DESCRIPTION
Manually add hotfix kernel used by Openshift 4.7.21, which is behind VPN. 

```bash
rhel_vpn_url="http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/kernel/4.18.0/240.23.2.el8_3/x86_64/kernel-devel-4.18.0-240.23.2.el8_3.x86_64.rpm" 
wget "${rhel_vpn_url}"
kernel_package_filename=$(echo "${rhel_vpn_url}" | tr -c 'a-zA-Z0-9_.\n' '-')
cp "${rpm_filename}" "${kernel_package_filename}"
gsutil cp "${kernel_package_filename}"  "gs://stackrox-kernel-packages/"
```

We should have automation to crawl these [kernels](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=RHELPLAN&title=RHEL+Kernel+Version+Table+RHEL+8.3.z+Stream) behind the VPN, I created https://stack-rox.atlassian.net/browse/ROX-7731 to track.