### PR TITLE
Docker for Mac fixes

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -16,6 +16,7 @@ import json
 import sys
 import urllib3
 from urllib3.util import parse_url as url_unquote
+from urllib.parse import urljoin, urlparse
 from lxml import html
 import traceback
 import re
@@ -260,7 +261,7 @@ repos = {
             "root": "https://docs.docker.com/desktop/mac/release-notes/",
             "download_root": "",
             "discovery_pattern": "",
-            "page_pattern": "/html/body//a[regex:test(@href, '^https://desktop.docker.com/mac/stable/.*/Docker.dmg$')]/@href",
+            "page_pattern": "/html/body//a[regex:test(@href, '^https://desktop.docker.com/mac/stable/(?!arm64).*/Docker.dmg.*$')]/@href",
             "subdirs": [""],
             "exclude_patterns": docker_desktop_excludes,
         },
@@ -595,8 +596,9 @@ def crawl(distro):
                             if "include_patterns" in repo and not any(check_pattern(x,rpm) for x in repo["include_patterns"]):
                                 continue
                             else:
-                                sys.stderr.write("Adding package " + rpm + "\n")
-                                raw_url = "{}{}".format(download_root, url_unquote(rpm))
+                                base_url = urljoin(rpm, urlparse(rpm).path)
+                                raw_url = "{}{}".format(download_root, url_unquote(base_url))
+                                sys.stderr.write("Adding package " + raw_url + "\n")
                                 prefix, suffix = raw_url.split('://', maxsplit=1)
                                 kernel_urls.append('://'.join((prefix, os.path.normpath(suffix))))
                     except urllib3.exceptions.HTTPError as e:

--- a/kernel-package-lists/docker-desktop-dmg.txt
+++ b/kernel-package-lists/docker-desktop-dmg.txt
@@ -1,18 +1,13 @@
 https://desktop.docker.com/mac/stable/amd64/66090/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/66090/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/66501/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/66501/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/63152/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/63152/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/64133/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/64133/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/61853/Docker.dmg
 https://desktop.docker.com/mac/stable/50773/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/61504/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/66024/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/66024/Docker.dmg
+https://desktop.docker.com/mac/stable/amd64/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/65384/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/65384/Docker.dmg
 https://desktop.docker.com/mac/stable/51484/Docker.dmg
 https://desktop.docker.com/mac/stable/50684/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/62916/Docker.dmg
@@ -21,4 +16,3 @@ https://desktop.docker.com/mac/stable/50996/Docker.dmg
 https://desktop.docker.com/mac/stable/51017/Docker.dmg
 https://desktop.docker.com/mac/stable/51218/Docker.dmg
 https://desktop.docker.com/mac/stable/amd64/63878/Docker.dmg
-https://desktop.docker.com/mac/stable/arm64/63878/Docker.dmg


### PR DESCRIPTION
- The most recent release does not have a build id but we should still crawl it, so update the regex: https://desktop.docker.com/mac/stable/amd64/Docker.dmg
- Don't crawl `arm64` releases