### PR TITLE
Jv/rox 7506 support minikube build root kernel

### DIFF
--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -260,6 +260,7 @@ crawl-fedora-coreos: build-crawl-container
 
 .PHONY: crawl-cos
 crawl-cos: build-crawl-container
+	docker run --rm -i kernel-crawler crawl Container-OptimizedOS > $(CRAWLED_PACKAGE_DIR)/cos.txt
 
 .PHONY: crawl-ubuntu-standard
 crawl-ubuntu-standard: build-crawl-container

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -581,6 +581,7 @@ repackage_minikube() {
 
         # extract kernel
         cd "${buildroot}"
+	export FORCE_UNSAFE_CONFIGURE=1
 	make linux
 
         local linux_src=$(find "${buildroot}/output/build" -maxdepth 1 -name 'linux-[0-9]*' | head -n1)


### PR DESCRIPTION
Goal is to be able to run Rox using Minikube. This is not currently working as the kernels used by the Minikube VM are not supported by Collector.