### PR TITLE
Fix repackage error on lakitu COS kernel

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -283,8 +283,8 @@ repos = {
             "type": "s3",
             "root": "https://storage.googleapis.com/cos-tools",
             "patterns": [
-                "kernel-src.tar.gz$",
-                "kernel-headers\.t(ar\.)?gz$",
+                "\d+\.\d+\.\d+/kernel-src.tar.gz$",
+                "\d+\.\d+\.\d+/kernel-headers\.t(ar\.)?gz$",
             ]
         },
     ],

--- a/kernel-package-lists/cos.txt
+++ b/kernel-package-lists/cos.txt
@@ -481,10 +481,6 @@ https://storage.googleapis.com/cos-tools/12871.1245.19/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/13310.1308.19/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/13310.1209.29/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/16108.0.69/kernel-src.tar.gz
-https://storage.googleapis.com/cos-tools/16778.0.0/lakitu/kernel-src.tar.gz
-https://storage.googleapis.com/cos-tools/13310.1366.11/lakitu/kernel-src.tar.gz
-https://storage.googleapis.com/cos-tools/16108.534.27/lakitu/kernel-src.tar.gz
-https://storage.googleapis.com/cos-tools/16623.39.28/lakitu/kernel-src.tar.gz
 https://storage.googleapis.com/cos-tools/11800.0.0/kernel-headers.tgz
 https://storage.googleapis.com/cos-tools/15130.0.0/kernel-headers.tgz
 https://storage.googleapis.com/cos-tools/16240.0.0/kernel-headers.tgz
@@ -861,7 +857,3 @@ https://storage.googleapis.com/cos-tools/12871.1245.19/kernel-headers.tgz
 https://storage.googleapis.com/cos-tools/13310.1308.19/kernel-headers.tgz
 https://storage.googleapis.com/cos-tools/13310.1209.29/kernel-headers.tgz
 https://storage.googleapis.com/cos-tools/16108.0.69/kernel-headers.tgz
-https://storage.googleapis.com/cos-tools/16778.0.0/lakitu/kernel-headers.tgz
-https://storage.googleapis.com/cos-tools/13310.1366.11/lakitu/kernel-headers.tgz
-https://storage.googleapis.com/cos-tools/16108.534.27/lakitu/kernel-headers.tgz
-https://storage.googleapis.com/cos-tools/16623.39.28/lakitu/kernel-headers.tgz


### PR DESCRIPTION
Remove unwanted kernels and only crawl future COS releases in the first-level directory after build id.

I'm not sure what the 'lakitu' kernel is, there is no reference I could in the documentation. The files were identical for `13310.1366.11`.