### PR TITLE
Fix COS build id regex so it works with lakitu kernels

### DIFF
--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -248,8 +248,8 @@ repackage_cos() {
 
         # Extract the build id from the cos package name it will be of the form,
         # 'https---storage.googleapis.com-cos-tools-10718.52.0-kernel-src.tar.gz'
-        local build_id="$(echo "$input_package" | sed 's/^.*-\([0-9]\+\.[0-9]\+\.[0-9]\+\)-kernel-src\.tar\.gz$/\1/')"
-        if [ -z $build_id ]; then 
+        local build_id="$(echo "$input_package" | sed 's/^.*-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(-lakitu\)\?-kernel-src\.tar\.gz$/\1/')"
+        if [ -z $build_id ]; then
             log "empty COS build id"
             return 1
         fi


### PR DESCRIPTION
A small adjustment on the build id regex for COS packages, required for lakitu kernels to be repackaged correctly.

The new regex is quite restrictive and will only allow for packages ending in `-kernel-src.tar.gz` or `lakitu-kernel-src.tar.gz`, it should work for now, but we might want to make it a little more permissive to account for future kernel version (by doing something like `.*-kernel-src\.tar\.gz$` )