### PR TITLE
Add rhel84 to reformat.yml

### DIFF
--- a/kernel-package-lists/reformat.yml
+++ b/kernel-package-lists/reformat.yml
@@ -190,6 +190,12 @@
   file: rhel82-eus.txt
   reformat: single
 
+- name: rhel84-eus
+  description: RHEL 8.4 EUS Kernels
+  type: redhat
+  file: rhel84-eus.txt
+  reformat: single
+
 - name: rhel8-rhocp4.3
   description: RHEL 8 OpenShift Container Platform 4.3
   type: redhat


### PR DESCRIPTION
As a followup to https://github.com/stackrox/kernel-packer/pull/167, without a reformat entry, the crawled kernel are not added to the manifest.yml

Testing: 

- [x] check for creation of `gs://stackrox-kernel-bundles-staging/rc/rhel-84-eus/319e9e8afd861978ce9d8a5ea7de4afb458aee92/bundle-4.18.0-305.28.1.el8_4.x86_64.tgz`
