### PR TITLE
Use RHACS quay.io credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 
 defaultImage: &defaultImage
-  image: quay.io/cgorman1/apollo-ci:collector-0.3.7
+  image: quay.io/rhacs-eng/apollo-ci:collector-0.3.7
   auth:
-    username: $QUAY_CGORMAN1_RO_USER
-    password: $QUAY_CGORMAN1_RO_PASSWORD
+    username: $QUAY_RHACS_ENG_RO_USERNAME
+    password: $QUAY_RHACS_ENG_RO_PASSWORD
 
 defaults: &defaults
   docker:
@@ -311,7 +311,7 @@ workflows:
     jobs:
     - lint:
         context:
-          - quay-cgorman1-readonly
+          - quay-rhacs-eng-readonly
           - docker-io-pull
     - crawl:
         name: crawl-build
@@ -323,13 +323,13 @@ workflows:
         - crawl-build
     - combine:
         context:
-          - quay-cgorman1-readonly
+          - quay-rhacs-eng-readonly
           - docker-io-pull
         requires:
         - repackage
     - collector:
         context:
-          - quay-cgorman1-readonly
+          - quay-rhacs-eng-readonly
           - docker-io-pull
         requires:
         - combine


### PR DESCRIPTION
This PR changes the credentials used by our CI to access quay to the official RHACS one as well as the repository where the CI image is pulled from.