### PR TITLE
Jv/crawl rhel rt kernels

### DIFF
--- a/kernel-crawler/main.go
+++ b/kernel-crawler/main.go
@@ -231,8 +231,8 @@ func getRPMURLs(client *http.Client, baseURL string, primaryURL string, authToke
 					return nil, err
 				}
 
-				// Only keep kernel-devel and kernel-default-devel packages.
-				if pkg.Name != "kernel-devel" && pkg.Name != "kernel-default-devel" {
+				// Only keep kernel-devel, kernel-rt-devel, and kernel-default-devel packages.
+				if pkg.Name != "kernel-devel" && pkg.Name != "kernel-default-devel" && pkg.Name != "kernel-rt-devel" {
 					continue
 				}
 


### PR DESCRIPTION
We are currently having an on call situation for kernel 4.18.0-305.28.1.rt7.100.el8_4.x86_64. This should make it so that this kernel and others with rt in the name will be crawled.