### PR TITLE
Replace centos image with UBI 8

### DIFF
--- a/kernel-crawler/rhel-login/Dockerfile
+++ b/kernel-crawler/rhel-login/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM registry.access.redhat.com/ubi8/ubi:8.5
 
 RUN yum --disablerepo='*' makecache \
  && yum install -y subscription-manager


### PR DESCRIPTION
This PR replaces a centos 8 image with a UBI one.