### PR TITLE
Disable SUSE crawling due to manifest pairing error

### DIFF
--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -86,17 +86,18 @@ crawl-flatcar-beta: build-crawl-container
 
 .PHONY: crawl-suse
 crawl-suse: build-crawl-container
-	# Get repository auth tokens using SUSE mirroring proxy user/password credentials
-	@mkdir -p $(BUILD_DATA_DIR)/suse-repo-tokens
-	./suse/get-repo-tokens.sh > $(BUILD_DATA_DIR)/suse-repo-tokens/repos.json
-	docker run --rm \
-		-v "$(BUILD_DATA_DIR)/suse-repo-tokens:/suse-repo-tokens:ro" \
-		-v "$(ROOT_DIR_ABS)/kernel-crawler/suse:/suse:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-		kernel-crawler:latest \
-			-repos-file /suse-repo-tokens/repos.json \
-			-repos-names-file /suse/repo-names.txt \
-		> $(CRAWLED_PACKAGE_DIR)/suse.txt
+	@echo "WARNING: SUSE crawling is currently disabled"
+	## Get repository auth tokens using SUSE mirroring proxy user/password credentials
+	#@mkdir -p $(BUILD_DATA_DIR)/suse-repo-tokens
+	#./suse/get-repo-tokens.sh > $(BUILD_DATA_DIR)/suse-repo-tokens/repos.json
+	#docker run --rm \
+	#	-v "$(BUILD_DATA_DIR)/suse-repo-tokens:/suse-repo-tokens:ro" \
+	#	-v "$(ROOT_DIR_ABS)/kernel-crawler/suse:/suse:ro" \
+	#	--entrypoint /usr/bin/rhel-crawler \
+	#	kernel-crawler:latest \
+	#		-repos-file /suse-repo-tokens/repos.json \
+	#		-repos-names-file /suse/repo-names.txt \
+	#	> $(CRAWLED_PACKAGE_DIR)/suse.txt
 
 .PHONY: crawl-rhel
 crawl-rhel: build-crawl-container


### PR DESCRIPTION
Disable suse crawling due to oncall alerts for broken matching, it will be reverted by https://github.com/stackrox/kernel-packer/pull/182