### PR TITLE
Ignore connection timeout

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -656,6 +656,9 @@ def crawl(distro):
                     except urllib3.exceptions.HTTPError as e:
                         sys.stderr.write("WARN: Error for source: {}: {}\n".format(source, e))
 
+        except urllib3.exceptions.ConnectTimeoutError as e:
+            sys.stderr.write("WARN: Error for source: {}: {}\n".format(source, e))
+
         except Exception as e:
             sys.stderr.write("ERROR: "+str(type(e))+str(e)+"\n")
             traceback.print_exc()


### PR DESCRIPTION
Do not report ConnectionTimeoutError as fatal one. Those are usually
transient errors and do not convey any extra information (e.g. a
connection timeout can't hide throttling issues or any other situations
when the server doesn't process request for whatever reason), it should
be fine to make them not stop crawling process.