### PR TITLE
Skip subscription-manager install if broken

### DIFF
--- a/kernel-crawler/rhel-login/Dockerfile
+++ b/kernel-crawler/rhel-login/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.5
 
-RUN yum --disablerepo='*' makecache \
- && yum install -y subscription-manager
+RUN dnf --disablerepo='*' makecache \
+ && dnf install -y --skip-broken subscription-manager
 
 # Obtained via https://access.redhat.com/labs/rhpc
 COPY 69.pem /etc/pki/product-default/69.pem


### PR DESCRIPTION
On newer UBI images susbscription-manager is installed by default, so we should be safe to skip it if installation breaks.