### PR TITLE
Fix crawling URLs for Docker Desktop

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -277,7 +277,7 @@ repos = {
     ],
     "Docker-Desktop": [
         {
-            "root": "https://docs.docker.com/desktop/mac/release-notes/",
+            "root": "https://docs.docker.com/desktop/release-notes/",
             "download_root": "",
             "discovery_pattern": "",
             "page_pattern": "/html/body//a[regex:test(@href, '^https://desktop.docker.com/mac/main/(?!arm64).*/Docker.dmg.*$')]/@href",
@@ -285,7 +285,7 @@ repos = {
             "exclude_patterns": docker_desktop_excludes,
         },
         {
-            "root": "https://docs.docker.com/desktop/mac/release-notes/3.x/",
+            "root": "https://docs.docker.com/desktop/previous-versions/3.x-mac/",
             "download_root": "",
             "discovery_pattern": "",
             "page_pattern": "/html/body//a[regex:test(@href, '^https://desktop.docker.com/mac/stable/(?!arm64).*/Docker.dmg.*$')]/@href",


### PR DESCRIPTION
Seems the release of Docker Desktop for Linux has prompted a restructuring of the release notes page, this in turn broke our crawler. Replacing the URLs with their new counter parts should fix the issue.