### PR TITLE
Prepare scripts for google-cloud-sdk

### DIFF
--- a/.openshift-ci/google-cloud-sdk/init.sh
+++ b/.openshift-ci/google-cloud-sdk/init.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+which gcloud
+echo "Updating gcloud/gsutil ..."
+gcloud config set core/disable_prompts True
+gcloud components install gsutil -q
+gcloud components update -q
+gcloud auth activate-service-account --key-file <(echo "$GOOGLE_CREDENTIALS_KERNEL_CACHE")
+gcloud auth list
+
+# Sanity check
+echo "Using gsutil from $(which gsutil)"
+echo "Checking that gsutil binary is functional"
+gsutil ls 'gs://stackrox-kernel-packages/' >/dev/null

--- a/.openshift-ci/google-cloud-sdk/install.sh
+++ b/.openshift-ci/google-cloud-sdk/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Inspired by the implementation from CircleCI gcp-cli-orb
+# https://github.com/CircleCI-Public/gcp-cli-orb
+
 GOOGLE_CLOUD_SDK_VERSION=383.0.0
 
 install () {

--- a/.openshift-ci/google-cloud-sdk/install.sh
+++ b/.openshift-ci/google-cloud-sdk/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+GOOGLE_CLOUD_SDK_VERSION=383.0.0
+
+install () {
+  # Set sudo to work whether logged in as root user or non-root user
+  if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; w
+  curl -Ss --retry 5 https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-"${GOOGLE_CLOUD_SDK_VERSION}"-linux-x86_64.tar.gz | tar xz
+  echo 'source ~/google-cloud-sdk/path.bash.inc' >> $BASH_ENV
+}
+
+if [[ $(command -v gcloud) == "" ]]; then
+    install
+else
+    echo "gcloud CLI is already installed."
+w


### PR DESCRIPTION
There seems to be no standartized way of installing google-cloud-sdk,
simulare gcloud-orb explicitely via scripts.