### PR TITLE
Add link job

### DIFF
--- a/.openshift-ci/go-lint.sh
+++ b/.openshift-ci/go-lint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Perform basic linting activities for Go code:
+# * Use goimport package, that does sorting of imports and gofmt
+# * Run go tests
+
+go get golang.org/x/tools/cmd/goimports
+
+gofiles="$(find . -name '*.go' | grep -v /vendor/)"
+test -z "$(goimports -l -local github.com/stackrox/kernel-packer $gofiles)"
+
+go test -mod=mod -v ./...


### PR DESCRIPTION
New job is supposed to be running on OpenShiftCI and encapsulates
linting activity split across few steps in CircleCI.