### PR TITLE
Disable minikube repackage

### DIFF
--- a/kernel-package-lists/reformat.yml
+++ b/kernel-package-lists/reformat.yml
@@ -148,11 +148,11 @@
   file: ubuntu-azure-fips.txt
   reformat: pairs
 
-- name: minikube
-  description: Minikube VM Kernels
-  type: minikube
-  file: minikube.txt
-  reformat: single
+# - name: minikube
+#   description: Minikube VM Kernels
+#   type: minikube
+#   file: minikube.txt
+#   reformat: single
 
 - name: linuxkit
   description: Linuxkit VM Kernels

--- a/kernel-package-lists/reformat.yml
+++ b/kernel-package-lists/reformat.yml
@@ -148,6 +148,7 @@
   file: ubuntu-azure-fips.txt
   reformat: pairs
 
+# Waiting on ROX-11521
 # - name: minikube
 #   description: Minikube VM Kernels
 #   type: minikube


### PR DESCRIPTION
Minikube repackaging is broken for v1.26.0, this PR disables it temporarily while we look to fix it.

Tracking issue: [ROX-11521](https://issues.redhat.com/browse/ROX-11521)