### PR TITLE
Remove docker desktop from reformat

### DIFF
--- a/kernel-package-lists/reformat.yml
+++ b/kernel-package-lists/reformat.yml
@@ -250,9 +250,3 @@
   type: suse
   file: suse.txt
   reformat: suse
-
-- name: docker-desktop
-  description: Docker for Desktop
-  type: dockerdesktop
-  file: docker-desktop.txt
-  reformat: single


### PR DESCRIPTION
It was previously removed from the kernel-package-lists, thus clean it
up from the reformat as well.