### PR TITLE
Fix collector commit

### DIFF
--- a/.openshift-ci/crawler/collector.sh
+++ b/.openshift-ci/crawler/collector.sh
@@ -8,4 +8,4 @@ source .openshift-ci/crawler/env.sh
 source .openshift-ci/crawler/setup-staging.sh
 
 echo "Collector commit..."
-make robo-crawl-commit
+make robo-collector-commit


### PR DESCRIPTION
Use collector commit target, the robo-crawl-commit already runs in the `/.openshift-ci/crawler/sync.sh`