### PR TITLE
Make 'debianPackages' optional in garden linux crawler

### DIFF
--- a/kernel-crawler/garden-crawler.py
+++ b/kernel-crawler/garden-crawler.py
@@ -111,7 +111,7 @@ def get_kernel_versions(component_descriptors: list) -> list:
             for resource in component['component']['resources']
             for label in resource['labels']
             if label['name'] == metadata_label
-            for pkg in label['value']['debianPackages']
+            for pkg in label['value'].get('debianPackages', [])
             if 'linux-image' in pkg
         ]
 


### PR DESCRIPTION
This is a quick and dirty fix to the garden linux crawler.

Some new entries that match the metadata label we look for have been added into their `component-descriptor` file that don't container the `debianPackages` entry, this PR make said entry optional.