### PR TITLE
New minikube crawling

### DIFF
--- a/kernel-crawler/Dockerfile
+++ b/kernel-crawler/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update \
     git \
  && rm -rf /var/lib/apt
 
-RUN pip install --no-cache-dir \
-    lxml==4.2.4 urllib3==1.26.3 \
-    requests==2.27.1 pyyaml==6.0
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 COPY ["garden-crawler.py", "/"]
+COPY ["minikube-crawler.py", "/"]
 COPY ["kernel-crawler.py", "/"]
 COPY ["repo-crawler.py", "/"]
 COPY ["kope.io.asc", "/"]

--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -264,7 +264,7 @@ crawl-ubuntu-standard: build-crawl-container
 
 .PHONY: crawl-minikube
 crawl-minikube: build-crawl-container
-	docker run --rm -i --entrypoint python3 kernel-crawler minikube-crawler.py >> $(CRAWLED_PACKAGE_DIR)/minikube.txt
+	docker run --rm -i --entrypoint python3 kernel-crawler minikube-crawler.py > $(CRAWLED_PACKAGE_DIR)/minikube.txt
 
 .PHONY: crawl
 crawl: build-crawl-container crawl-suse crawl-rhel crawl-centos crawl-kops crawl-amazon crawl-debian crawl-ubuntu-esm crawl-ubuntu-gcp crawl-ubuntu-hwe crawl-ubuntu-gke crawl-oracle-uek crawl-ubuntu-azure crawl-flatcar crawl-flatcar-beta crawl-gardenlinux crawl-ubuntu-aws crawl-fedora-coreos crawl-cos crawl-ubuntu-standard crawl-minikube crawl-rhsm crawl-ubuntu-fips

--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -264,7 +264,7 @@ crawl-ubuntu-standard: build-crawl-container
 
 .PHONY: crawl-minikube
 crawl-minikube: build-crawl-container
-	docker run --rm -i kernel-crawler crawl Minikube > $(CRAWLED_PACKAGE_DIR)/minikube.txt
+	docker run --rm -i --entrypoint python3 kernel-crawler minikube-crawler.py >> $(CRAWLED_PACKAGE_DIR)/minikube.txt
 
 .PHONY: crawl
 crawl: build-crawl-container crawl-suse crawl-rhel crawl-centos crawl-kops crawl-amazon crawl-debian crawl-ubuntu-esm crawl-ubuntu-gcp crawl-ubuntu-hwe crawl-ubuntu-gke crawl-oracle-uek crawl-ubuntu-azure crawl-flatcar crawl-flatcar-beta crawl-gardenlinux crawl-ubuntu-aws crawl-fedora-coreos crawl-cos crawl-ubuntu-standard crawl-minikube crawl-rhsm crawl-ubuntu-fips

--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -67,17 +67,6 @@ docker_desktop_excludes = [
     "45519",
     "48029",
 ]
-minikube_excludes = [
-    "kubernetes/minikube/archive/v0.35.0.tar.gz",
-    "kubernetes/minikube/archive/v0.34.1.tar.gz",
-    "kubernetes/minikube/archive/v0.34.0.tar.gz",
-    "kubernetes/minikube/archive/v0.33.1.tar.gz",
-    "kubernetes/minikube/archive/v0.33.0.tar.gz",
-    "kubernetes/minikube/archive/v0.32.0.tar.gz",
-    "kubernetes/minikube/archive/v0.31.0.tar.gz",
-    "kubernetes/minikube/archive/v0.30.0.tar.gz",
-    "kubernetes/minikube/archive/v0.29.0.tar.gz",
-]
 garden_excludes = [
     "5.4.0",
     "dbgsym",
@@ -301,17 +290,6 @@ repos = {
                 "\d+\.\d+\.\d+/kernel-src.tar.gz$",
                 "\d+\.\d+\.\d+/kernel-headers\.t(ar\.)?gz$",
             ]
-        },
-    ],
-
-    "Minikube": [
-        {
-            "root": "https://github.com/kubernetes/minikube/releases",
-            "download_root": "https://github.com",
-            "discovery_pattern" : "",
-            "subdirs": [""],
-            "page_pattern" : "/html/body//a[regex:test(@href, '^/kubernetes/minikube/archive/refs/tags/v[0-9]+.[0-9]+.[0-9]+.tar.gz')]/@href",
-            "exclude_patterns": minikube_excludes,
         },
     ],
 

--- a/kernel-crawler/minikube-crawler.py
+++ b/kernel-crawler/minikube-crawler.py
@@ -70,15 +70,20 @@ def get_defconfig(repo, minikube_version):
 
 
 def print_config_files(kernel_data):
+    base_url = 'https://raw.githubusercontent.com/kubernetes/minikube'
     for kd in kernel_data:
-        print(f'https://raw.githubusercontent.com/kubernetes/minikube/{kd["version"]}/{kd["config"]}')
-        print(f'https://raw.githubusercontent.com/kubernetes/minikube/{kd["version"]}/{kd["minikube"]}')
+        print(f'{base_url}/{kd["version"]}/{kd["config"]}?kernel={kd["kernel"]}')
 
 
 def print_kernel_packages(kernel_data):
+    urls = set()
+    base_url = 'https://cdn.kernel.org/pub/linux/kernel'
     for kd in kernel_data:
         version = semver.VersionInfo.parse(kd['kernel'])
-        print(f'https://cdn.kernel.org/pub/linux/kernel/v{version.major}.x/linux-{kd["kernel"]}.tar.xz')
+        urls.add(f'{base_url}/v{version.major}.x/linux-{kd["kernel"]}.tar.xz')
+
+    for url in urls:
+        print(url)
 
 
 def main():

--- a/kernel-crawler/minikube-crawler.py
+++ b/kernel-crawler/minikube-crawler.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python3
+
+# This crawler is loosely based on falco's crawler for minikube
+# You can find it here:
+# https://github.com/falcosecurity/kernel-crawler/blob/e2bbe6455ef26941e3f53f9f6481e7a610746484/kernel_crawler/minikube.py
+
+import tempfile
+import sys
+import os
+import re
+import semver
+import pygit2
+
+
+def clone_repo():
+    work_dir = tempfile.mkdtemp(prefix="minikube-")
+    return pygit2.clone_repository("https://github.com/kubernetes/minikube.git", work_dir)
+
+
+def filter_versions(version):
+    if semver.compare('1.24.0', version) > 0:
+        return False
+
+    semver_version = semver.VersionInfo.parse(version)
+    return semver_version.prerelease is None and semver_version.build is None
+
+
+def get_versions(repo):
+    re_tags = re.compile('^refs/tags/v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$')
+
+    all_versions = [os.path.basename(v).strip('v') for v in repo.references if re_tags.match(v)]
+    filtered_versions = list(filter(filter_versions, all_versions))
+
+    return filtered_versions
+
+
+def get_minikube_config_file_name(version):
+    if semver.compare('1.26.0', version) <= 0:
+        return 'minikube_x86_64_defconfig'
+    return 'minikube_defconfig'
+
+
+def get_kernel_config_file_name(version):
+    if semver.compare('1.26.0', version) <= 0:
+        return 'linux_x86_64_defconfig'
+    return 'linux_defconfig'
+
+
+def search_files(directory, file_name):
+    for dirpath, dirnames, files in os.walk(directory, followlinks=True):
+        for name in files:
+            if name == file_name:
+                return os.path.join(dirpath, name)
+    return None
+
+
+def get_kernel_release(repo, version):
+    # here kernel release is the same as the one given by "uname -r"
+    file_name = get_minikube_config_file_name(version)
+    full_path = search_files(repo.workdir, file_name)
+    for line in open(full_path):
+        if re.search(r'^BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=', line):
+            tokens = line.strip().split('=')
+            return full_path[len(repo.workdir):], tokens[1].strip('"')
+
+
+def get_defconfig(repo, minikube_version):
+    file_name = get_kernel_config_file_name(minikube_version)
+    return search_files(repo.workdir, file_name)[len(repo.workdir):]
+
+
+def print_config_files(kernel_data):
+    for kd in kernel_data:
+        print(f'https://raw.githubusercontent.com/kubernetes/minikube/{kd["version"]}/{kd["config"]}')
+        print(f'https://raw.githubusercontent.com/kubernetes/minikube/{kd["version"]}/{kd["minikube"]}')
+
+
+def print_kernel_packages(kernel_data):
+    for kd in kernel_data:
+        version = semver.VersionInfo.parse(kd['kernel'])
+        print(f'https://cdn.kernel.org/pub/linux/kernel/v{version.major}.x/linux-{kd["kernel"]}.tar.xz')
+
+
+def main():
+    repo_handle = clone_repo()
+    versions = get_versions(repo_handle)
+
+    kernel_data = []
+    for v in versions:
+        repo_handle.checkout(f'refs/tags/v{v}')
+        minikube_defconfig, kernel_release = get_kernel_release(repo_handle, v)
+        kernel_config = get_defconfig(repo_handle, v)
+        kernel_data.append({
+            'kernel': kernel_release,
+            'version': f'v{v}',
+            'config': kernel_config,
+            'minikube': minikube_defconfig,
+        })
+
+    print_config_files(kernel_data)
+    print_kernel_packages(kernel_data)
+
+
+if __name__ == '__main__':
+    main()

--- a/kernel-crawler/requirements.txt
+++ b/kernel-crawler/requirements.txt
@@ -1,0 +1,7 @@
+lxml==4.2.4
+urllib3==1.26.3
+requests==2.27.1
+pyyaml==6.0
+semver==2.13.0
+sh==1.14.2
+pygit2==1.10.1

--- a/kernel-package-lists/reformat.yml
+++ b/kernel-package-lists/reformat.yml
@@ -148,12 +148,11 @@
   file: ubuntu-azure-fips.txt
   reformat: pairs
 
-# Waiting on ROX-11521
-# - name: minikube
-#   description: Minikube VM Kernels
-#   type: minikube
-#   file: minikube.txt
-#   reformat: single
+- name: minikube
+  description: Minikube VM Kernels
+  type: minikube
+  file: minikube.txt
+  reformat: minikube
 
 - name: linuxkit
   description: Linuxkit VM Kernels

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -558,60 +558,41 @@ repackage_ubuntu() {
 
 # Repackages a minikube kernel into a bundle tarball.
 repackage_minikube() {
-    if [[ $# -ne 3 ]]; then
+    if [[ $# -ne 4 ]]; then
         log "invalid number of arguments"
         return 1
     fi
 
     local checksum="$1"
     local output_dir="$2"
-    local input_package_1="$3"
+    local config="$3"
+    local kernel_headers="$4"
 
-    local minikube="$(mktemp -d)"
-    local buildroot="${minikube}/out/buildroot"
+    [[ "$config" =~ -v([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*kernel-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+) ]] || {
+        log "Failed to match minikube version ${config}"
+        return 1
+    }
+    local kernel_version="${BASH_REMATCH[2]}-v${BASH_REMATCH[1]}"
+
+    local linux_src="$(mktemp -d)"
     (
-        tar --strip 1 -C "${minikube}" -xzf "${input_package_1}"
-        cd "${minikube}"
-
-        # extract buildroot
-	sed -i 's|^minikube_iso:.*|minikube_iso:|' Makefile # Make it so that auto-pause is not built. This means we do not need to worry about the go version.
-        sed -i '/$(MAKE) -C $(BUILD_DIR)\/buildroot/d' Makefile # Make it so that the minikube iso is not actually built
-	sed -i '/rootfs.iso9660/d' Makefile # Since we are not creating the iso, don't move the iso
-        make minikube_iso
-
-        # extract kernel
-        cd "${buildroot}"
-	export FORCE_UNSAFE_CONFIGURE=1
-	make linux
-
-        local linux_src=$(find "${buildroot}/output/build" -maxdepth 1 -name 'linux-[0-9]*' | head -n1)
-        local kernel_version="$(echo "$linux_src" | sed -n 's/^.*\/linux-\([0-9]\+\.[0-9]\+\.[0-9]\+\)$/\1/p')"
-        if [ ! -n "$kernel_version" ]; then
-            kernel_version="$(echo "$linux_src" | sed 's/^.*\/linux-\([0-9]\+\.[0-9]\+\)$/\1/').0"
-        fi
-
-        if [[ -z "$kernel_version" ]]; then
-            log "invalid kernel version"
-            return 1
-        fi
-
-	local kernel_version_minikube="${kernel_version}-minikube"
-
-        log "Kernel version is $kernel_version_minikube"
-
-        ## prepare kernel
+        tar --strip 1 -C "${linux_src}" -xzf "${kernel_headers}"
         cd "${linux_src}"
-        make olddefconfig
-        make modules_prepare
+
+        cp "${config}" .config
+
+        make KCONFIG_CONFIG=.config oldconfig
+        make KCONFIG_CONFIG=.config prepare
+        make KCONFIG_CONFIG=.config modules_prepare
 
         # Generate bundle meta files
-        meta_dir="$(bundle_meta "$checksum" 'minikube' "$kernel_version_minikube" '.')"
+        meta_dir="$(bundle_meta "$checksum" 'minikube' "$kernel_version" '.')"
 
         # Compress only part of the file hierarchy into a tarball.
         tar --create --dereference --hard-dereference --file - \
             --directory "$meta_dir" . \
             --directory "${linux_src}" . \
-        | pigz -9 -c > "${output_dir}/bundle-${kernel_version_minikube}.tgz"
+        | pigz -9 -c > "${output_dir}/bundle-${kernel_version}.tgz"
 
     )
 }

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -574,6 +574,8 @@ repackage_minikube() {
     }
     local kernel_version="${BASH_REMATCH[2]}-minikube-v${BASH_REMATCH[1]}"
 
+    log "Kernel version is ${kernel_version}"
+
     local linux_src="$(mktemp -d)"
     (
         tar --strip 1 -C "${linux_src}" -xf "${kernel_headers}"
@@ -581,9 +583,9 @@ repackage_minikube() {
 
         cp "${config}" .config
 
-        make KCONFIG_CONFIG=.config oldconfig
-        make KCONFIG_CONFIG=.config prepare
-        make KCONFIG_CONFIG=.config modules_prepare
+        yes "" | make KCONFIG_CONFIG=.config oldconfig > /dev/null
+        yes "" | make KCONFIG_CONFIG=.config prepare > /dev/null
+        yes "" | make KCONFIG_CONFIG=.config modules_prepare > /dev/null
 
         # Generate bundle meta files
         meta_dir="$(bundle_meta "$checksum" 'minikube' "$kernel_version" '.')"

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -572,7 +572,7 @@ repackage_minikube() {
         log "Failed to match minikube version ${config}"
         return 1
     }
-    local kernel_version="${BASH_REMATCH[2]}-v${BASH_REMATCH[1]}"
+    local kernel_version="${BASH_REMATCH[2]}-minikube-v${BASH_REMATCH[1]}"
 
     local linux_src="$(mktemp -d)"
     (

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -576,7 +576,7 @@ repackage_minikube() {
 
     local linux_src="$(mktemp -d)"
     (
-        tar --strip 1 -C "${linux_src}" -xzf "${kernel_headers}"
+        tar --strip 1 -C "${linux_src}" -xf "${kernel_headers}"
         cd "${linux_src}"
 
         cp "${config}" .config

--- a/packers/entrypoint
+++ b/packers/entrypoint
@@ -583,9 +583,11 @@ repackage_minikube() {
 
         cp "${config}" .config
 
-        yes "" | make KCONFIG_CONFIG=.config oldconfig > /dev/null
-        yes "" | make KCONFIG_CONFIG=.config prepare > /dev/null
-        yes "" | make KCONFIG_CONFIG=.config modules_prepare > /dev/null
+        make olddefconfig > /dev/null
+        make modules_prepare > /dev/null
+
+        # Delete all *.c files, excluding scripts directory
+        find "${linux_src}" ! \( -type d \) -not -path "${linux_src}/scripts/*" -name "*.c" -delete
 
         # Generate bundle meta files
         meta_dir="$(bundle_meta "$checksum" 'minikube' "$kernel_version" '.')"

--- a/tools/command/command.go
+++ b/tools/command/command.go
@@ -69,9 +69,6 @@ func DockerCommand(checksum string, distroName string, outputDir string, package
 	// Add the Docker image name, distro name, and output directory alias
 	args = append(args, "repackage:latest", checksum, distroName, "/output")
 
-	// Add the docker socket so we can use other images as repackagers
-	args = append(args, "-v", "/var/run/docker.sock", "/var/run/docker.sock")
-
 	// Add a series of package names, same as the volume aliases.
 	for _, pkg := range packages {
 		args = append(args, fmt.Sprintf("/input/%s", filepath.Base(pkg)))

--- a/tools/command/command.go
+++ b/tools/command/command.go
@@ -69,6 +69,9 @@ func DockerCommand(checksum string, distroName string, outputDir string, package
 	// Add the Docker image name, distro name, and output directory alias
 	args = append(args, "repackage:latest", checksum, distroName, "/output")
 
+	// Add the docker socket so we can use other images as repackagers
+	args = append(args, "-v", "/var/run/docker.sock", "/var/run/docker.sock")
+
 	// Add a series of package names, same as the volume aliases.
 	for _, pkg := range packages {
 		args = append(args, fmt.Sprintf("/input/%s", filepath.Base(pkg)))

--- a/tools/generate-manifest/reformatters/reformatters.go
+++ b/tools/generate-manifest/reformatters/reformatters.go
@@ -429,12 +429,14 @@ var (
 	minikubeKernelVersionRe = regexp.MustCompile(`(?:kernel=)((\d+)\.\d+\.\d+)`)
 )
 
-// reformatMinikube consumes a list of packages and configuration files
-// and will return groups of kernel headers with the configuration to be used
-// for a given minikube version
+// reformatMinikube consumes a list of configuration files and will return
+// groups of kernel headers with the configuration to be used for a given
+// minikube version. The reasone the kernel URL is recreated here is that
+// the groups we receive are grouped by URL, so we ignore the cdn.kernel ones
+// and recreate them when going through the configuration files.
 //
 // For example:
-// [foo/v.1.24.0/something?kernel=4.19.202, foo/v.1.25.0/something?kernel=4.19.202, bar/v4.x/linux-4.19.202.tar.xz] ->
+// [foo/v.1.24.0/something?kernel=4.19.202, foo/v.1.25.0/something?kernel=4.19.202], [bar/v4.x/linux-4.19.202.tar.xz] ->
 // [[foo/v.1.24.0/something?kernel=4.19.202, bar/v4.x/linux-4.19.202.tar.xz], [foo/v.1.25.0/something?kernel=4.19.202, bar/v4.x/linux-4.19.202.tar.xz]]
 func reformatMinikube(packages []string) ([][]string, error) {
 	versions := make([][]string, 0, len(packages))


### PR DESCRIPTION
This PR refactors minikube kernel crawling and repackaging.

The new way of crawling is to use the minikube repository, going through its tags and taking note of both the path to the kernel config file and version being used to build their ISO. Then the crawler outputs a GitHub raw URL for the config file and a cdn.kernel.org URL to the vanilla header files.

Repackaging is mostly the same as the existing `linuxkit` repackager, but using the config file downloaded from github with the vanilla kernel headers.