### PR TITLE
Change GPC instance type

### DIFF
--- a/.openshift-ci/gcp/create-vm.sh
+++ b/.openshift-ci/gcp/create-vm.sh
@@ -56,7 +56,7 @@ createGCPVM() {
             --image-family "$GCP_IMAGE_FAMILY" \
             --image-project "$GCP_IMAGE_PROJECT" \
             --scopes="storage-rw,cloud-platform"\
-            --machine-type n2-standard-16 \
+            --machine-type e2-standard-16 \
             --labels="stackrox-kernel-crawler-osci=true,stackrox-osci-job=${BUILD_ID}" \
             --boot-disk-size=300GB \
             "$GCP_VM_NAME"; then


### PR DESCRIPTION
N2 instance type is prone to CPU limitations during our configuration for some projects. But in fact it's not needed any more, switch it back to E2.