### PR TITLE
Remove unreachable and unused Garden Linux URLs

### DIFF
--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -34,8 +34,7 @@ crawl-kops: build-crawl-container
 
 .PHONY: crawl-gardenlinux
 crawl-gardenlinux: build-crawl-container
-	docker run --rm -i kernel-crawler crawl Garden-Linux >$(CRAWLED_PACKAGE_DIR)/gardenlinux.txt
-	docker run --rm -i --entrypoint python3 kernel-crawler garden-crawler.py >> $(CRAWLED_PACKAGE_DIR)/gardenlinux.txt
+	docker run --rm -i --entrypoint python3 kernel-crawler garden-crawler.py > $(CRAWLED_PACKAGE_DIR)/gardenlinux.txt
 
 .PHONY: crawl-debian
 crawl-debian: build-crawl-container

--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -612,22 +612,6 @@ repos = {
             "subdirs":  [""],
             "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-devel-[0-9].*\.rpm$')]/@href",
          }
-    ],
-    "Garden-Linux" : [
-        {
-            "root": "http://45.86.152.1/gardenlinux/pool/main/l/",
-            "discovery_pattern": "/html/body//a[regex:test(@href, '^linux/')]/@href",
-            "subdirs": [""],
-            "page_pattern": "/html/body//a[regex:test(@href, '^linux-headers-[4-9].[0-9.]+-[^-]+-(?:cloud-)?(?:amd64|common_).*(?:amd64|all).deb$')]/@href",
-            "exclude_patterns": garden_excludes,
-        },
-        {
-            "root": "http://45.86.152.1/gardenlinux/pool/main/l/",
-            "discovery_pattern": "/html/body//a[regex:test(@href, '^linux/')]/@href",
-            "subdirs": [""],
-            "page_pattern": "/html/body//a[regex:test(@href, '^linux-kbuild-[4-9]\..*_amd64\.deb$')]/@href",
-            "exclude_patterns": garden_excludes,
-        }
     ]
 }
 


### PR DESCRIPTION
The URLs were still being crawled, but new Garden Linux kernels are actually retrieved from GitHub's release artifacts. So these should be safe to remove.