### PR TITLE
Allow access to SUSE credentials

### DIFF
--- a/.openshift-ci/crawler/env.sh
+++ b/.openshift-ci/crawler/env.sh
@@ -13,6 +13,12 @@ gcloud secrets versions access latest \
 echo >> $BASH_ENV
 
 gcloud secrets versions access latest \
+    --secret="collector-kernel-crawler-suse-credentials" \
+    | sed -e 's/^/export /' >> $BASH_ENV
+
+echo >> $BASH_ENV
+
+gcloud secrets versions access latest \
     --secret="collector-kernel-crawler-ubuntu-credentials" \
     | sed -e 's/^/export /' >> $BASH_ENV
 


### PR DESCRIPTION
Add the newly created SUSE secret crawling credentials to the list of secrets being used.