### PR TITLE
Set the machine ID used for ubuntu FIPS crawling through a secret

### DIFF
--- a/Makefile-constants.mk
+++ b/Makefile-constants.mk
@@ -19,5 +19,5 @@ KERNEL_PACKAGE_BUCKET ?= gs://stackrox-kernel-packages
 KERNEL_BUNDLE_BUCKET ?= gs://stackrox-kernel-bundles
 
 # Ubuntu FIPS contract URLs
-UBUNTU_FIPS_ATTACH_URL ?= https://contracts.canonical.com/v1/resources/fips/context/machines/930f3ea7ac23ddc47f14216b9249d216
-UBUNTU_FIPS_UPDATES_ATTACH_URL ?= https://contracts.canonical.com/v1/resources/fips-updates/context/machines/930f3ea7ac23ddc47f14216b9249d216
+UBUNTU_FIPS_ATTACH_URL ?= https://contracts.canonical.com/v1/resources/fips/context/machines/$(UBUNTU_FIPS_MACHINE_ID)
+UBUNTU_FIPS_UPDATES_ATTACH_URL ?= https://contracts.canonical.com/v1/resources/fips-updates/context/machines/$(UBUNTU_FIPS_MACHINE_ID)


### PR DESCRIPTION
Pretty self explanatory, the machine ID on its own is not of much use but is would be better to obfuscate it, plus it makes it easier to rotate it if we ever need to.