### PR TITLE
Fix missing secrets in crawl workflow

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -8,6 +8,7 @@ jobs:
     env:
       # this is used in a number of steps, and is set here to avoid
       # duplication.
+      RHSM_OFFLINE_TOKEN: ${{ secrets.RHSM_OFFLINE_TOKEN }}
       REDHAT_USERNAME: ${{ secrets.REDHAT_USERNAME }}
       REDHAT_PASSWORD: ${{ secrets.REDHAT_PASSWORD }}
       REDHAT_SUBSCRIPTION_ORG_ID: ${{ secrets.REDHAT_SUBSCRIPTION_ORG_ID }}

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -8,7 +8,14 @@ jobs:
     env:
       # this is used in a number of steps, and is set here to avoid
       # duplication.
-      RHSM_OFFLINE_TOKEN: ${{ secrets.RHSM_OFFLINE_TOKEN }}
+      REDHAT_USERNAME: ${{ secrets.REDHAT_USERNAME }}
+      REDHAT_PASSWORD: ${{ secrets.REDHAT_PASSWORD }}
+      REDHAT_SUBSCRIPTION_ORG_ID: ${{ secrets.REDHAT_SUBSCRIPTION_ORG_ID }}
+      REDHAT_SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.REDHAT_SUBSCRIPTION_ACTIVATION_KEY }}
+      SUSE_MIRRORING_USERNAME: ${{ secrets.SUSE_MIRRORING_USERNAME }}
+      SUSE_MIRRORING_PASSWORD: ${{ secrets.SUSE_MIRRORING_PASSWORD }}
+      UBUNTU_ESM_SUBSCRIPTION_TOKEN: ${{ secrets.UBUNTU_ESM_SUBSCRIPTION_TOKEN }}
+      UBUNTU_FIPS_SUBSCRIPTION_TOKEN: ${{ secrets.UBUNTU_FIPS_SUBSCRIPTION_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v1
@@ -19,15 +26,6 @@ jobs:
       - uses: ./.github/actions/env
 
       - name: Run crawl
-        env:
-          REDHAT_USERNAME: ${{ secrets.REDHAT_USERNAME }}
-          REDHAT_PASSWORD: ${{ secrets.REDHAT_PASSWORD }}
-          REDHAT_SUBSCRIPTION_ORG_ID: ${{ secrets.REDHAT_SUBSCRIPTION_ORG_ID }}
-          REDHAT_SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.REDHAT_SUBSCRIPTION_ACTIVATION_KEY }}
-          SUSE_MIRRORING_USERNAME: ${{ secrets.SUSE_MIRRORING_USERNAME }}
-          SUSE_MIRRORING_PASSWORD: ${{ secrets.SUSE_MIRRORING_PASSWORD }}
-          UBUNTU_ESM_SUBSCRIPTION_TOKEN: ${{ secrets.UBUNTU_ESM_SUBSCRIPTION_TOKEN }}
-          UBUNTU_FIPS_SUBSCRIPTION_TOKEN: ${{ secrets.UBUNTU_FIPS_SUBSCRIPTION_TOKEN }}
         run: |
           if ! make -k crawl 2> >(tee /tmp/make-crawl-stderr >&2) ; then
               touch /tmp/crawl-failed
@@ -44,8 +42,6 @@ jobs:
         run: |
           make sync
           git --no-pager diff kernel-package-lists
-        env:
-          RHSM_OFFLINE_TOKEN: ${{ secrets.RHSM_OFFLINE_TOKEN }}
 
       - name: Manifest
         run: |


### PR DESCRIPTION
This moves all the secrets to the top-level environment for the crawl job to avoid the possibility of missing a secret in each individual step.