### PR TITLE
Enable production buckets and committing to the GHA workflows

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -13,12 +13,11 @@ runs:
         KERNEL_BUNDLE_STAGING_BUCKET: "gs://stackrox-kernel-bundles-staging"
       run: |
 
-        # TODO: uncomment if statement when transitioning away from OSCI
-        #if [[ "${{ github.event_name }}" != "schedule" ]]; then
+        if [[ "${{ github.event_name }}" != "schedule" ]]; then
           echo "Using staging buckets"
           KERNEL_PACKAGE_BUCKET="${KERNEL_PACKAGE_STAGING_BUCKET},${KERNEL_PACKAGE_BUCKET}"
           KERNEL_BUNDLE_BUCKET="${KERNEL_BUNDLE_STAGING_BUCKET},${KERNEL_BUNDLE_BUCKET}"
-        #fi
+        fi
 
         echo "KERNEL_PACKAGE_BUCKET=${KERNEL_PACKAGE_BUCKET}" | tee -a "$GITHUB_ENV"
         echo "KERNEL_BUNDLE_BUCKET=${KERNEL_BUNDLE_BUCKET}" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -54,10 +54,11 @@ jobs:
           rm -rf build-data/downloads
           rm -rf build-data/packages
 
-          # TODO: reenable once OSCI is turned off
-          #- name: Crawl commit
-          #  if: ${{ github.event_name != 'pull_request' }}
-          #  run: make robo-crawl-commit
+      - name: Crawl commit
+        if: github.event_name != 'pull_request'
+        run: make robo-crawl-commit
+        env:
+          ROBOT_ROX_GITHUB_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
 
       #
       # The manifest is used in subsequent workflows. Archive it here

--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -166,12 +166,11 @@ jobs:
           IFS=',' read -r -a bucket_names <<< "${KERNEL_BUNDLE_BUCKET}"
           gsutil cp .build-data/cache/cache.yml "${bucket_names[0]}/cache.yml"
 
-          # TODO: reenable once OSCI is disabled
-          #- name: Commit to Collector Repo
-          #  if: ${{ github.event_name != 'pull_request' }}
-          #  run: make robo-collector-commit
-          #  env:
-          #    ROBOT_ROX_GITHUB_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+      - name: Commit to Collector Repo
+        if: github.event_name != 'pull_request'
+        run: make robo-collector-commit
+        env:
+          ROBOT_ROX_GITHUB_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
   notify:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Once https://github.com/openshift/release/pull/35678 has merged, we will rely on GHA for kernel-packer. This PR ensures the correct buckets are used and enables the committing features.