### PR TITLE
Removes output suppression of robo-crawl-commit git push command

### DIFF
--- a/scripts/robo-crawl-commit
+++ b/scripts/robo-crawl-commit
@@ -32,7 +32,7 @@ main() {
     # redirect to devnull so this doesn't print the value of the token on failure.
     # temporary test branch
     echo "Push changes..."
-    git push pushtarget $BRANCH &> /dev/null
+    git push pushtarget $BRANCH
     echo "Crawled packages have been pushed."
 }
 


### PR DESCRIPTION
This is primarily to get some better visibility on the current failures on master