### PR TITLE
Fix manifest file download directory

### DIFF
--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -40,9 +40,7 @@ jobs:
           path: kernel-package-lists
 
       - name: List packages
-        run: |
-          ls -alh kernel-package-lists
-          make list-files
+        run: make list-files
 
       - name: Split package file
         id: split-packages

--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -37,9 +37,12 @@ jobs:
           # this is archived by the crawl workflow
           # see .github/workflows/crawl.yml for details
           name: kernel-crawler-manifest
+          path: kernel-package-lists
 
       - name: List packages
-        run: make list-files
+        run: |
+          ls -alh kernel-package-lists
+          make list-files
 
       - name: Split package file
         id: split-packages


### PR DESCRIPTION
I have a suspicion that the manifest file is incorrectly downloaded to the repo root directory and that prevents the repackaging step from picking up new crawled kernels. 