### PR TITLE
Add uncrawled Garden Linux packages

### DIFF
--- a/kernel-package-lists/gardenlinux-uncrawled.txt
+++ b/kernel-package-lists/gardenlinux-uncrawled.txt
@@ -12,3 +12,7 @@ http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15
 http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.77-gardenlinux-cloud-amd64_5.15.77-0gardenlinux1_amd64.deb
 http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.77-gardenlinux-amd64_5.15.77-0gardenlinux1_amd64.deb
 http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-kbuild-5.15_5.15.77-0gardenlinux1_amd64.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.81-gardenlinux-common_5.15.81-0gardenlinux1_all.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.81-gardenlinux-cloud-amd64_5.15.81-0gardenlinux1_amd64.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.81-gardenlinux-amd64_5.15.81-0gardenlinux1_amd64.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-kbuild-5.15_5.15.81-0gardenlinux1_amd64.deb


### PR DESCRIPTION
This PR adds the missing packages for version 934.2 of Garden Linux. I will be following this PR with a bump to the VM being used for testing in stackrox/collector.