### PR TITLE
Improves logging clarity

### DIFF
--- a/scripts/sync
+++ b/scripts/sync
@@ -40,7 +40,8 @@ main() {
         filename="$(simplify "$url")"
 
         # Check if this specific file exists in the bucket listing.
-        if ! echo "$all_bucket_files" | contains_exact "$filename"; then
+        # redirect to /dev/null to suppress broken pipe errors
+        if ! echo "$all_bucket_files" 2>/dev/null | contains_exact "$filename"; then
             echo "Downloading $url and uploading to bucket"
 
             # This file didn't exist in the bucket listing, so download it.


### PR DESCRIPTION
Suppresses broken pipe errors when echoing into `grep -q`, which may exit early and break the stdout of echo