### PR TITLE
Fixes manifest download in repackaging step

### DIFF
--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -120,6 +120,7 @@ jobs:
           # this is archived by the crawl workflow
           # see .github/workflows/crawl.yml for details
           name: kernel-crawler-manifest
+          path: kernel-package-lists
 
       - name: Download Jobs
         uses: actions/download-artifact@v3


### PR DESCRIPTION
In the repackaging step, the manifest is downloaded to the root of the directory instead of the kernel-package-lists directory, which results in some mistakes in repackaging. This fixes that by defining the download path. 