### PR TITLE
Add kernels for 934.3 Garden Linux version

### DIFF
--- a/kernel-package-lists/gardenlinux-uncrawled.txt
+++ b/kernel-package-lists/gardenlinux-uncrawled.txt
@@ -16,3 +16,7 @@ http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15
 http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.81-gardenlinux-cloud-amd64_5.15.81-0gardenlinux1_amd64.deb
 http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.81-gardenlinux-amd64_5.15.81-0gardenlinux1_amd64.deb
 http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-kbuild-5.15_5.15.81-0gardenlinux1_amd64.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.88-gardenlinux-common_5.15.88-0gardenlinux1_all.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.88-gardenlinux-cloud-amd64_5.15.88-0gardenlinux1_amd64.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.88-gardenlinux-amd64_5.15.88-0gardenlinux1_amd64.deb
+http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-kbuild-5.15_5.15.88-0gardenlinux1_amd64.deb


### PR DESCRIPTION
This PR adds the packages needed for the latest Garden Linux version.