### PR TITLE
Fix the regex used for searching make errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Check errors
       run: |
-        if [[ -f /tmp/crawl-failed ]] || grep -Eq '\*\*\* \[[a-zA-Z0-9-]+\] Error' /tmp/make-crawl-stderr ; then
+        if [[ -f /tmp/crawl-failed ]] || grep -Eq '\*\*\* \[[:[:space:]a-zA-Z0-9-]+\] Error' /tmp/make-crawl-stderr ; then
             echo >&2 "'make crawl' failed."
             exit 1
         fi


### PR DESCRIPTION
The regex used for checking the crawler output for make error lines has been broken since its implementation. This commit fixes it by adding colons and spaces to the contents of the group between brackets.