### PR TITLE
Downgrade missing kbuild error

### DIFF
--- a/tools/generate-manifest/reformatters/reformatters.go
+++ b/tools/generate-manifest/reformatters/reformatters.go
@@ -2,6 +2,7 @@ package reformatters
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"path"
 	"regexp"
@@ -226,7 +227,9 @@ func reformatDebian(packages []string) ([][]string, error) {
 		}
 
 		if len(kbuildCandidates) == 0 {
-			return nil, errors.Errorf("failed to find kbuild package for kernel version %s: candidates are %+v", version, kbuildsByKernelVersion)
+			log.Printf("failed to find kbuild package for kernel version %s: "+
+				"candidates are %+v", version, kbuildsByKernelVersion)
+			continue
 		}
 
 		sort.Slice(kbuildCandidates, func(i, j int) bool {


### PR DESCRIPTION
Debian crawler discovered linux-kbuild-4.9.0-13 was removed from [[1]], leaving only linux-kbuild-4.9_4.9.228, but not for amd64 architecture. At the same time linux-headers-4.9.0-13 are still there (including amd64). Which is a problem for reformatter, as it tries to match every header and kbuild package. Since not much could be done about missing package, downgrade the error to a log message and continue with the rest.

[1]: http://debian.csail.mit.edu/debian/pool/main/l/linux/