### PR TITLE
Disable legacy rhel crawl

### DIFF
--- a/kernel-crawler/Makefile
+++ b/kernel-crawler/Makefile
@@ -140,118 +140,6 @@ crawl-rhsm: build-rhsm-crawler
 	docker run -e RHSM_OFFLINE_TOKEN --rm -i -v $(CRAWLED_PACKAGE_DIR):/kernel-package-lists:ro rhsm-crawler:latest > $(CRAWLED_PACKAGE_DIR)/rhel.txt
 	@sed -i 's/[@\^\r]//g' $(CRAWLED_PACKAGE_DIR)/rhel.txt
 
-.PHONY: crawl-rhel
-crawl-rhel: build-crawl-container
-	# Trade a username & password for a certificate keypair that allows up to
-	# authenticate with the RHEL package repos.
-	@mkdir -p $(BUILD_DATA_DIR)/rhel-certs
-	docker run --rm \
-		-e REDHAT_USERNAME \
-		-e REDHAT_PASSWORD \
-		rhel-login:latest \
-	| tar -C $(BUILD_DATA_DIR)/rhel-certs -xf -
-
-	ls -alh $(BUILD_DATA_DIR)/rhel-certs
-
-	# Crawl for RHEL 7 kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-		-base-url https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os \
-		-cert /rhel-certs/rhel-cert.pem \
-		-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel7.txt
-
-	# Crawl for RHEL 8 kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel8.txt
-
-	# Crawl for RHEL 8.1 kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/dist/rhel8/8.1/x86_64/baseos/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel81.txt
-
-	# Crawl for RHEL 8.2 kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/baseos/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel82.txt
-
-	# Crawl for RHEL 7.6 EUS (Extended Update Support) kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/eus/rhel/server/7/7.6/x86_64/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel76-eus.txt
-
-	# Crawl for RHEL 8.1 EUS (Extended Update Support) kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/eus/rhel8/8.1/x86_64/baseos/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel81-eus.txt
-
-	# Crawl for RHEL 8.2 EUS (Extended Update Support) kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/eus/rhel8/8.2/x86_64/baseos/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel82-eus.txt
-
-	# Crawl for RHEL 8.4 EUS (Extended Update Support) kernel-devel packages.
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/eus/rhel8/8.4/x86_64/baseos/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel84-eus.txt
-
-	# Crawl for Red Hat OpenShift Container Platform 4.3 for RHEL 8 x86_64 (rhocp-4.3-for-rhel-8-x86_64-rpms)
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/rhocp/4.3/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel8-rhocp4.3.txt
-
-	# Crawl for Red Hat OpenShift Container Platform 4.4 for RHEL 8 x86_64 (rhocp-4.4-for-rhel-8-x86_64-rpms)
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/rhocp/4.4/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel8-rhocp4.4.txt
-
-	## Crawl for Red Hat OpenShift Container Platform 4.5 for RHEL 8 x86_64 (rhocp-4.5-for-rhel-8-x86_64-rpms)
-	./scripts/run-crawler.py \
-		-v "$(BUILD_DATA_DIR)/rhel-certs:/rhel-certs:ro" \
-		--entrypoint /usr/bin/rhel-crawler \
-			-base-url https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/rhocp/4.5/os \
-			-cert /rhel-certs/rhel-cert.pem \
-			-key /rhel-certs/rhel-key.pem \
-		> $(CRAWLED_PACKAGE_DIR)/rhel8-rhocp4.5.txt
-
 .PHONY: crawl-fedora-coreos
 crawl-fedora-coreos: build-crawl-container
 	./scripts/run-crawler.py crawl Fedora-CoreOS > $(CRAWLED_PACKAGE_DIR)/fedora-coreos.txt
@@ -271,7 +159,7 @@ crawl-minikube: build-crawl-container
 		minikube-crawler.py > $(CRAWLED_PACKAGE_DIR)/minikube.txt
 
 .PHONY: crawl
-crawl: build-crawl-container crawl-suse crawl-rhel
+crawl: build-crawl-container crawl-suse
 crawl: crawl-centos crawl-kops crawl-amazon crawl-debian
 crawl: crawl-ubuntu-esm crawl-ubuntu-gcp crawl-ubuntu-hwe
 crawl: crawl-ubuntu-gke crawl-oracle-uek crawl-ubuntu-azure

--- a/kernel-crawler/rhel-subscription-crawler/crawler.py
+++ b/kernel-crawler/rhel-subscription-crawler/crawler.py
@@ -246,7 +246,7 @@ class Crawler:
                 endpoint += '?filter=latest'
 
             for packages in self.paginate_request(endpoint, session):
-                repo_urls = self.filter_kernel_headers(packages)
+                repo_urls = self.filter_kernel_headers(packages, repo)
                 urls |= repo_urls
 
                 # Crawling all repos is expensive so save the ones that actually have packages we are
@@ -259,7 +259,7 @@ class Crawler:
 
         return urls
 
-    def filter_kernel_headers(self, packages):
+    def filter_kernel_headers(self, packages, repo):
         urls = set()
         for pkg in packages:
             pkg_name = pkg['name']
@@ -284,7 +284,7 @@ class Crawler:
 
             urls.add(url)
 
-            logger.debug(kernel)
+            logger.info(f' {repo} {kernel}')
 
 
         return urls


### PR DESCRIPTION
* Disable the legacy `crawl-rhel` workflow. The `crawl-rhsm` workflow is sufficient.
* Add kernel package and repo logging to the `crawl-rhsm` output