### PR TITLE
Temporary exclude latest Ubuntu headers

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -42,6 +42,8 @@ centos_excludes = [
 ubuntu_excludes = [
     "5.10.0-13.14",  # excluding this kernel because only the `all` pkg is available, the `amd64` pkg is missing.
     "5.15.0-1001.3", # excluding this kernel because only the `all` pkg is available, the `amd64` pkg is missing.
+    "6.2.0-23", # excluding this kernel temporarily due to dkpg compatibility issues, ROX-17277.
+    "6.3.0-4", # excluding this kernel temporarily due to dkpg compatibility issues, ROX-17277.
 ]
 ubuntu_backport_supported = [
     "16.04",


### PR DESCRIPTION
Crawler repackaging is failing for latest Ubuntu linux-headers version 6.2.0-23 and 6.3.0-4. The reason is crawling repackaging is using `debian:buster`, which doesn't have dpkg version that supports zstd compression. Unfortunately it got enabled on the latest packages for Ubuntu.