### PR TITLE
Trigger PR build on label change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Kernel Packer
 
 on:
   pull_request:
+    types: [opened, reopened, labeled, unlabeled]
   schedule:
     - cron: '15 */2 * * *'
 


### PR DESCRIPTION
The default `pull_request` trigger type implicitly includes `opened` and `reopened`.
Make that explicit and add label related types.