### PR TITLE
Trigger pipeline on PR push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Kernel Packer
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
   schedule:
     - cron: '15 */2 * * *'
 


### PR DESCRIPTION
When making the trigger event types explicit, in order to add the label related ones,
the 'synchronized' one was forgotten.