### PR TITLE
Block Ubuntu kernel 6.8.0-20.20 and cos 18342

### DIFF
--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -42,6 +42,7 @@ centos_excludes = [
 ubuntu_excludes = [
     "5.10.0-13.14",  # excluding this kernel because only the `all` pkg is available, the `amd64` pkg is missing.
     "5.15.0-1001.3", # excluding this kernel because only the `all` pkg is available, the `amd64` pkg is missing.
+    "6.8.0-20.20",   # excluding this kernel because only the `all` pkg is available, the `amd64` pkg is missing.
 ]
 ubuntu_backport_supported = [
     "16.04",

--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -72,6 +72,9 @@ garden_excludes = [
     "5.4.0",
     "dbgsym",
 ]
+cos_excludes = [
+    "18342.0.0",
+]
 repos = {
     "CentOS" : [
         {
@@ -291,6 +294,7 @@ repos = {
                 "\d+\.\d+\.\d+/kernel-src.tar.gz$",
                 "\d+\.\d+\.\d+/kernel-headers\.t(ar\.)?gz$",
             ]
+            "exclude_patterns": cos_excludes,
         },
     ],
 

--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -682,6 +682,8 @@ def crawl_s3(repo):
             for pattern in repo['patterns']:
                 if re.search(pattern, key):
                     result = "{}/{}".format(repo['root'], key)
+                    if "exclude_patterns" in repo and any(check_pattern(x,result) for x in repo["exclude_patterns"]):
+                        continue
                     results.append(result)
     results.sort()
     return results

--- a/kernel-crawler/kernel-crawler.py
+++ b/kernel-crawler/kernel-crawler.py
@@ -293,7 +293,7 @@ repos = {
             "patterns": [
                 "\d+\.\d+\.\d+/kernel-src.tar.gz$",
                 "\d+\.\d+\.\d+/kernel-headers\.t(ar\.)?gz$",
-            ]
+            ],
             "exclude_patterns": cos_excludes,
         },
     ],


### PR DESCRIPTION
w.r.t the Ubuntu kernel only the all package is available for this kernel and it causes the crawler to fail, so we should block it.

The COS kernel has a known issue upstream in the v6.8.2 were some header includes are missing, so we'll block that one since we cannot compile it.