### PR TITLE
chore(CI): use rhacs-bot

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -86,8 +86,8 @@ jobs:
         run: make robo-crawl-commit
         env:
           RHACS_BOT_GITHUB_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
-          RHACS_BOT_GITHUB_EMAIL: ${{ secrets.RHACS_BOT_GITHUB_EMAIL }}
-          RHACS_BOT_GITHUB_USERNAME: ${{ secrets.RHACS_BOT_GITHUB_USERNAME }}
+          RHACS_BOT_GITHUB_EMAIL: ${{ vars.RHACS_BOT_GITHUB_EMAIL }}
+          RHACS_BOT_GITHUB_USERNAME: ${{ vars.RHACS_BOT_GITHUB_USERNAME }}
 
       #
       # The manifest is used in subsequent workflows. Archive it here

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -85,7 +85,9 @@ jobs:
         if: github.event_name != 'pull_request'
         run: make robo-crawl-commit
         env:
-          ROBOT_ROX_GITHUB_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+          RHACS_BOT_GITHUB_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+          RHACS_BOT_GITHUB_EMAIL: ${{ secrets.RHACS_BOT_GITHUB_EMAIL }}
+          RHACS_BOT_GITHUB_USERNAME: ${{ secrets.RHACS_BOT_GITHUB_USERNAME }}
 
       #
       # The manifest is used in subsequent workflows. Archive it here

--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -95,7 +95,9 @@ jobs:
         if: github.event_name != 'pull_request'
         run: make robo-collector-commit
         env:
-          ROBOT_ROX_GITHUB_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
+          RHACS_BOT_GITHUB_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+          RHACS_BOT_GITHUB_EMAIL: ${{ secrets.RHACS_BOT_GITHUB_EMAIL }}
+          RHACS_BOT_GITHUB_USERNAME: ${{ secrets.RHACS_BOT_GITHUB_USERNAME }}
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -96,8 +96,8 @@ jobs:
         run: make robo-collector-commit
         env:
           RHACS_BOT_GITHUB_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
-          RHACS_BOT_GITHUB_EMAIL: ${{ secrets.RHACS_BOT_GITHUB_EMAIL }}
-          RHACS_BOT_GITHUB_USERNAME: ${{ secrets.RHACS_BOT_GITHUB_USERNAME }}
+          RHACS_BOT_GITHUB_EMAIL: ${{ vars.RHACS_BOT_GITHUB_EMAIL }}
+          RHACS_BOT_GITHUB_USERNAME: ${{ vars.RHACS_BOT_GITHUB_USERNAME }}
 
   notify:
     runs-on: ubuntu-latest

--- a/scripts/robo-collector-commit
+++ b/scripts/robo-collector-commit
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-ROBOT_ROX_GITHUB_TOKEN="${ROBOT_ROX_GITHUB_TOKEN:-$GITHUB_TOKEN}"
+RHACS_BOT_GITHUB_TOKEN="${RHACS_BOT_GITHUB_TOKEN:-$GITHUB_TOKEN}"
 
 main() {
     local kernel_bundle_bucket="$1"
@@ -34,7 +34,7 @@ clone_collector() {
     # Redirect to devnull so this doesn't print the value of the token on
     # failure.
     git clone\
-        https://roxbot:$ROBOT_ROX_GITHUB_TOKEN@github.com/stackrox/collector.git\
+        "https://$RHACS_BOT_GITHUB_USERNAME:$RHACS_BOT_GITHUB_TOKEN@github.com/stackrox/collector.git"\
         "$collector_repo_dir"\
         --depth 1  &> /dev/null
 }
@@ -45,8 +45,8 @@ commit_files() {
     git -C "$collector_repo_dir" add -- kernel-modules/KERNEL_VERSIONS
 
     git -C "$collector_repo_dir" \
-        -c "user.email=roxbot@stackrox.com" \
-        -c "user.name=roxbot" \
+        -c "user.email=$RHACS_BOT_GITHUB_EMAIL" \
+        -c "user.name=$RHACS_BOT_GITHUB_USERNAME" \
         commit --message "🤖 Updated crawled kernels"
 }
 

--- a/scripts/robo-crawl-commit
+++ b/scripts/robo-crawl-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-ROBOT_ROX_GITHUB_TOKEN="${ROBOT_ROX_GITHUB_TOKEN:-$GITHUB_TOKEN}"
+RHACS_BOT_GITHUB_TOKEN="${RHACS_BOT_GITHUB_TOKEN:-$GITHUB_TOKEN}"
 
 main() {
     CRAWLED_PACKAGE_DIR="${1:-kernel-package-lists}"
@@ -22,17 +22,17 @@ main() {
     # it first. Redirect to devnull so this doesn't print the value of the
     # token on failure.
     echo "Add target..."
-    git remote add pushtarget https://roxbot:$ROBOT_ROX_GITHUB_TOKEN@github.com/stackrox/kernel-packer &> /dev/null
+    git remote add pushtarget "https://$RHACS_BOT_GITHUB_USERNAME:$RHACS_BOT_GITHUB_TOKEN@github.com/stackrox/kernel-packer" &> /dev/null
 
     # Create a commit with any modified files, and push it to GitHub.
     echo "Commit changes..."
     git add "$CRAWLED_PACKAGE_DIR"
-    git -c "user.name=roxbot" -c "user.email=roxbot@stackrox.com" commit --message "🤖 Updated crawled packages"
+    git -c "user.name=$RHACS_BOT_GITHUB_USERNAME" -c "user.email=$RHACS_BOT_GITHUB_EMAIL" commit --message "🤖 Updated crawled packages"
 
     # redirect to devnull so this doesn't print the value of the token on failure.
     # temporary test branch
     echo "Push changes..."
-    git push pushtarget $BRANCH
+    git push pushtarget "$BRANCH"
     echo "Crawled packages have been pushed."
 }
 


### PR DESCRIPTION
`roxbot` is being retired in favor of `rhacs-bot`.

## Testing

- [x] - tested the crawl commit to kernel-packer on this PR (history overwritten by forced push)
- [x] - tested the repackage commit to collector repo ([job](https://github.com/stackrox/kernel-packer/actions/runs/8989693539/job/24694468432))
  - committed to a test branch on collector with the same protection rule override as main: https://github.com/stackrox/collector/commits/gavin/test-kerel-packer-collector-commit/  