### PR TITLE
Disable scheduled crawling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,6 @@ name: Kernel Packer
 on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
-  schedule:
-    - cron: '15 */2 * * *'
 
 jobs:
   crawl:


### PR DESCRIPTION
I've left pull requests enabled, in case, for whatever reason, we want to fiddle with the repo. 